### PR TITLE
Get away from master/slave terminology

### DIFF
--- a/devices/eurotherm_2404.py
+++ b/devices/eurotherm_2404.py
@@ -36,7 +36,7 @@ class eurotherm_2404( minimalmodbus.Instrument ):
 
     Args:
         * portname (str): port name
-        * slaveaddress (int): slave address in the range 1 to 247
+        * subordinateaddress (int): subordinate address in the range 1 to 247
 
     Implemented with these function codes (in decimal):
         
@@ -57,7 +57,7 @@ class eurotherm_2404( minimalmodbus.Instrument ):
 
     """
     
-    def __init__(self, portname, slaveaddress=1):
+    def __init__(self, portname, subordinateaddress=1):
         self.oven_name = str(portname)
         self.oven_constant = 0.000078 # default value
         if "/" not in portname: # means instead of a serial port name, a pseudoname has been used
@@ -69,7 +69,7 @@ class eurotherm_2404( minimalmodbus.Instrument ):
                 self.oven_constant = 0
                 self.oven_name = ""
                 sys.exit("No furnace with the name: \""+str(portname)+"\" has been found. Is the controller really Eurotherm 2404? Don't you think it's a Eurotherm 2416 or 3216? Either use a correct pseudoname or address the serial port directly (See manual)")
-        minimalmodbus.Instrument.__init__(self, portname, slaveaddress=1)
+        minimalmodbus.Instrument.__init__(self, portname, subordinateaddress=1)
         self.room_temperature = 23
         print "###########################################################################"
         print "       "+self.oven_name+" (with id: "+str(self.get_id())+")"

--- a/devices/eurotherm_2416.py
+++ b/devices/eurotherm_2416.py
@@ -29,7 +29,7 @@ class eurotherm_2416( minimalmodbus.Instrument ):
 
     Args:
         * portname (str): port name
-        * slaveaddress (int): slave address in the range 1 to 247
+        * subordinateaddress (int): subordinate address in the range 1 to 247
 
     Implemented with these function codes (in decimal):
         
@@ -50,7 +50,7 @@ class eurotherm_2416( minimalmodbus.Instrument ):
 
     """
     
-    def __init__(self, portname, slaveaddress=1):
+    def __init__(self, portname, subordinateaddress=1):
         self.oven_name = str(portname)
         self.oven_constant = 0.000078 # default value
         if "/" not in portname: # means instead of a serial port name, a pseudoname has been used
@@ -66,7 +66,7 @@ class eurotherm_2416( minimalmodbus.Instrument ):
                 self.oven_constant = 0
                 self.oven_name = ""
                 sys.exit("No furnace with the name: \""+str(portname)+"\" has been found. Is the controller really Eurotherm 2416? Don't you think it's a Eurotherm 3216? Either use a correct pseudoname or address the serial port directly (See manual)")
-        minimalmodbus.Instrument.__init__(self, portname, slaveaddress=1)
+        minimalmodbus.Instrument.__init__(self, portname, subordinateaddress=1)
         self.room_temperature = 23
         print "###########################################################################"
         print "       "+self.oven_name+" (with id: "+str(self.get_id())+")"

--- a/devices/eurotherm_3216.py
+++ b/devices/eurotherm_3216.py
@@ -29,7 +29,7 @@ class eurotherm_3216( minimalmodbus.Instrument ):
 
     Args:
         * portname (str): port name
-        * slaveaddress (int): slave address in the range 1 to 247
+        * subordinateaddress (int): subordinate address in the range 1 to 247
 
     Implemented with these function codes (in decimal):
         
@@ -51,7 +51,7 @@ class eurotherm_3216( minimalmodbus.Instrument ):
     
     """
     
-    def __init__(self, portname, slaveaddress=1):
+    def __init__(self, portname, subordinateaddress=1):
         self.oven_name = str(portname)
         self.oven_constant = 0.000078 # default value
         if "/" not in portname: # means instead of a serial port name, a pseudoname has been used
@@ -91,7 +91,7 @@ class eurotherm_3216( minimalmodbus.Instrument ):
                 self.oven_constant = 0
                 self.oven_name = "unknown oven"
                 sys.exit("No furnace with the name: \""+str(portname)+"\" has been found. Is the controller really Eurotherm 3216? Don't you think it's a Eurotherm 2416? Either use a correct pseudoname or address the serial port directly (See manual)")
-        minimalmodbus.Instrument.__init__(self, portname, slaveaddress=1)
+        minimalmodbus.Instrument.__init__(self, portname, subordinateaddress=1)
         self.room_temperature = 23
         print "###########################################################################"
         print "       "+self.oven_name+" (with id: "+str(self.get_id())+")"

--- a/devices/eurotherm_3500.py
+++ b/devices/eurotherm_3500.py
@@ -44,7 +44,7 @@ class eurotherm_3500( minimalmodbus.Instrument ):
 
     Args:
         * portname (str): port name
-        * slaveaddress (int): slave address in the range 1 to 247
+        * subordinateaddress (int): subordinate address in the range 1 to 247
 
     Implemented with these function codes (in decimal):
         
@@ -57,8 +57,8 @@ class eurotherm_3500( minimalmodbus.Instrument ):
 
     """
     
-    def __init__(self, portname, slaveaddress=1):
-        minimalmodbus.Instrument.__init__(self, portname, slaveaddress=1)
+    def __init__(self, portname, subordinateaddress=1):
+        minimalmodbus.Instrument.__init__(self, portname, subordinateaddress=1)
         self.room_temperature = 23
     ## Process value
     

--- a/devices/eurotherm_nanodac.py
+++ b/devices/eurotherm_nanodac.py
@@ -28,7 +28,7 @@ class eurotherm_nanodac( minimalmodbus.Instrument ):
 
     Args:
         * portname (str): port name
-        * slaveaddress (int): slave address in the range 1 to 247
+        * subordinateaddress (int): subordinate address in the range 1 to 247
 
     Implemented with these function codes (in decimal):
         
@@ -41,8 +41,8 @@ class eurotherm_nanodac( minimalmodbus.Instrument ):
 
     """
     
-    def __init__(self, portname, slaveaddress=1):
-        minimalmodbus.Instrument.__init__(self, portname, slaveaddress)
+    def __init__(self, portname, subordinateaddress=1):
+        minimalmodbus.Instrument.__init__(self, portname, subordinateaddress)
         self.room_temperature = 23
         
     ## Process value

--- a/devices/minimalmodbus-0-7.py
+++ b/devices/minimalmodbus-0-7.py
@@ -89,16 +89,16 @@ MODE_ASCII = 'ascii'
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU or ASCII protocols (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU or ASCII protocols (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``COM4`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
         * mode (str): Mode selection. Can be MODE_RTU or MODE_ASCII.
 
     """
 
-    def __init__(self, port, slaveaddress, mode=MODE_RTU):
+    def __init__(self, port, subordinateaddress, mode=MODE_RTU):
         if port not in _SERIALPORTS or not _SERIALPORTS[port]:
             self.serial = _SERIALPORTS[port] = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, stopbits=STOPBITS, timeout=TIMEOUT)
         else:
@@ -122,11 +122,11 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.mode = mode
-        """Slave mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
+        """Subordinate mode (str), can be MODE_RTU or MODE_ASCII.  Most often set by the constructor (see the class documentation).
 
         New in version 0.6.
         """
@@ -147,7 +147,7 @@ class Instrument():
         self.handle_local_echo = False
         """Set to to :const:`True` if your RS-485 adaptor has local echo enabled. 
         Then the transmitted message will immeadiately appear at the receive line of the RS-485 adaptor.
-        MinimalModbus will then read and discard this data, before reading the data from the slave.
+        MinimalModbus will then read and discard this data, before reading the data from the subordinate.
         Defaults to :const:`False`.
 
         New in version 0.7.
@@ -171,15 +171,15 @@ class Instrument():
             )
 
     ######################################
-    ## Methods for talking to the slave ##
+    ## Methods for talking to the subordinate ##
     ######################################
 
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -194,10 +194,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -214,17 +214,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -239,7 +239,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -259,21 +259,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -297,17 +297,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -326,9 +326,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -336,8 +336,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -356,9 +356,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -369,12 +369,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -393,17 +393,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -420,13 +420,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -444,16 +444,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -473,12 +473,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -499,17 +499,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -546,11 +546,11 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770,
-        then use ``numberOfDecimals=1`` which will divide the received data from the slave by 10
+        If a value of 77.0 is stored internally in the subordinate register as 770,
+        then use ``numberOfDecimals=1`` which will divide the received data from the subordinate by 10
         before returning the value. Similarly ``numberOfDecimals=2`` will divide
         the received data by 100 before returning the value. Same functionality is also used
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -648,25 +648,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -688,37 +688,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave = _numToTwoByteString(registeraddress) + \
+            payloadToSubordinate = _numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -726,7 +726,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -754,15 +754,15 @@ class Instrument():
     ##########################################
 
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -775,16 +775,16 @@ class Instrument():
         DEFAULT_NUMBER_OF_BYTES_TO_READ = 1000
 
         _checkFunctioncode(functioncode, None)
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
         # Build request
-        request = _embedPayload(self.address, self.mode, functioncode, payloadToSlave)
+        request = _embedPayload(self.address, self.mode, functioncode, payloadToSubordinate)
 
         # Calculate number of bytes to read
         number_of_bytes_to_read = DEFAULT_NUMBER_OF_BYTES_TO_READ
         if self.precalculate_read_size:
             try:
-                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSlave)
+                number_of_bytes_to_read = _predictResponseSize(self.mode, functioncode, payloadToSubordinate)
             except:
                 if self.debug:
                     template = 'MinimalModbus debug mode. Could not precalculate response size for Modbus {} mode. ' + \
@@ -795,19 +795,19 @@ class Instrument():
         response = self._communicate(request, number_of_bytes_to_read)
 
         # Extract payload
-        payloadFromSlave = _extractPayload(response, self.address, self.mode, functioncode)
-        return payloadFromSlave
+        payloadFromSubordinate = _extractPayload(response, self.address, self.mode, functioncode)
+        return payloadFromSubordinate
 
 
     def _communicate(self, request, number_of_bytes_to_read):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            request (str): The raw request that is to be sent to the slave.
+            request (str): The raw request that is to be sent to the subordinate.
             number_of_bytes_to_read (int): number of bytes to read
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -825,9 +825,9 @@ class Instrument():
 
         Timing::
 
-                                                  Request from master (Master is writing)
+                                                  Request from main (Main is writing)
                                                   |
-                                                  |       Response from slave (Master is reading)
+                                                  |       Response from subordinate (Main is reading)
                                                   |       |
             ----W----R----------------------------W-------R----------------------------------------
                      |                            |       |
@@ -936,35 +936,35 @@ class Instrument():
 ####################
 
 
-def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
-    """Build a request from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, mode, functioncode, payloaddata):
+    """Build a request from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * mode (str): The modbus protcol mode (MODE_RTU or MODE_ASCII)
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) request string for sending to the slave (including CRC etc).
+        The built (raw) request string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
     The resulting request has the format:
-     * RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
-     * ASCII Mode: header (:) + slaveaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
+     * RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+     * ASCII Mode: header (:) + subordinateaddress (2 characters) + functioncode (2 characters) + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    The LRC or CRC is calculated from the byte string made up of slaveaddress + functioncode + payloaddata.
+    The LRC or CRC is calculated from the byte string made up of subordinateaddress + functioncode + payloaddata.
     The header, LRC/CRC, and footer are excluded from the calculation.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
 
     if mode == MODE_ASCII:
         request = _ASCII_HEADER + \
@@ -977,12 +977,12 @@ def _embedPayload(slaveaddress, mode, functioncode, payloaddata):
     return request
 
 
-def _extractPayload(response, slaveaddress, mode, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, mode, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * mode (str): The modbus protcol mode (MODE_RTU or MODE_ASCII)
         * functioncode (int): Used here for error checking only.
 
@@ -993,10 +993,10 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
     The received response should have the format:
-    * RTU Mode: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
-    * ASCII Mode: header (:) + slaveaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
+    * RTU Mode: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+    * ASCII Mode: header (:) + subordinateaddress byte + functioncode byte + payloaddata + LRC (which is two characters) + footer (CRLF)
 
-    For development purposes, this function can also be used to extract the payload from the request sent TO the slave.
+    For development purposes, this function can also be used to extract the payload from the request sent TO the subordinate.
 
     """
     BYTEPOSITION_FOR_ASCII_HEADER          = 0  # Relative to plain response
@@ -1014,7 +1014,7 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
 
@@ -1074,18 +1074,18 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
                 response, plainresponse)
         raise ValueError(text)
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord(response[BYTEPOSITION_FOR_SLAVEADDRESS])
 
-    if responseaddress != slaveaddress:
-        raise ValueError('Wrong return slave address: {} instead of {}. The response is: {!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError('Wrong return subordinate address: {} instead of {}. The response is: {!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord(response[BYTEPOSITION_FOR_FUNCTIONCODE])
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {} instead of {}. The response is: {!r}'.format( \
@@ -1107,13 +1107,13 @@ def _extractPayload(response, slaveaddress, mode, functioncode):
 ############################################
 
 
-def _predictResponseSize(mode, functioncode, payloadToSlave):
-    """Calculate the number of bytes that should be received from the slave.
+def _predictResponseSize(mode, functioncode, payloadToSubordinate):
+    """Calculate the number of bytes that should be received from the subordinate.
 
     Args:
      * mode (str): The modbus protcol mode (MODE_RTU or MODE_ASCII)
      * functioncode (int): Modbus function code.
-     * payloadToSlave (str): The raw request that is to be sent to the slave (not hex encoded string)
+     * payloadToSubordinate (str): The raw request that is to be sent to the subordinate (not hex encoded string)
 
     Returns:
         The preducted number of bytes (int) in the response.
@@ -1138,14 +1138,14 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
     # Argument validity testing
     _checkMode(mode)
     _checkFunctioncode(functioncode, None)
-    _checkString(payloadToSlave, description='payload', minlength=MIN_PAYLOAD_LENGTH)
+    _checkString(payloadToSubordinate, description='payload', minlength=MIN_PAYLOAD_LENGTH)
 
     # Calculate payload size
     if functioncode in [5, 6, 15, 16]:
         response_payload_size = NUMBER_OF_PAYLOAD_BYTES_IN_WRITE_CONFIRMATION
 
     elif functioncode in [1, 2, 3, 4]:
-        given_size = _twoByteStringToNum(payloadToSlave[BYTERANGE_FOR_GIVEN_SIZE])
+        given_size = _twoByteStringToNum(payloadToSubordinate[BYTERANGE_FOR_GIVEN_SIZE])
         if functioncode == 1 or functioncode == 2:
             # Algorithm from MODBUS APPLICATION PROTOCOL SPECIFICATION V1.1b
             number_of_inputs = given_size
@@ -1159,7 +1159,7 @@ def _predictResponseSize(mode, functioncode, payloadToSlave):
 
     else:
         raise ValueError('Wrong functioncode: {}. The payload is: {!r}'.format( \
-            functioncode, payloadToSlave))
+            functioncode, payloadToSubordinate))
 
     # Calculate number of bytes to read
     if mode == MODE_ASCII:
@@ -1232,8 +1232,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1326,7 +1326,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1358,7 +1358,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1388,11 +1388,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
     encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1433,7 +1433,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1472,14 +1472,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1501,13 +1501,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1571,7 +1571,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -2065,11 +2065,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -2078,7 +2078,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):
@@ -2373,12 +2373,12 @@ def _interpretRawMessage(inputstr):
         Modbus bytestring decoder
         Input string (length 8 characters): '\n\x03\x10\x01\x00\x01\xd0q'
         Probably modbus RTU mode.
-        Slave address: 10 (dec). Function code: 3 (dec).
+        Subordinate address: 10 (dec). Function code: 3 (dec).
         Valid message. Extracted payload: '\x10\x01\x00\x01'
 
         Pos   Character Hex  Dec  Probable interpretation 
         -------------------------------------------------
-          0:  '\n'      0A    10  Slave address 
+          0:  '\n'      0A    10  Subordinate address 
           1:  '\x03'    03     3  Function code 
           2:  '\x10'    10    16  Payload    
           3:  '\x01'    01     1  Payload    
@@ -2400,26 +2400,26 @@ def _interpretRawMessage(inputstr):
         mode = MODE_RTU
     output += 'Probably Modbus {} mode.\n'.format(mode.upper())
 
-    # Extract slave address and function code
+    # Extract subordinate address and function code
     try:
         if mode == MODE_ASCII:
-            slaveaddress = int(inputstr[1:3])
+            subordinateaddress = int(inputstr[1:3])
             functioncode = int(inputstr[3:5])
         else:
-            slaveaddress = ord(inputstr[0])
+            subordinateaddress = ord(inputstr[0])
             functioncode = ord(inputstr[1])
-        output += 'Slave address: {} (dec). Function code: {} (dec).\n'.format(slaveaddress, functioncode)
+        output += 'Subordinate address: {} (dec). Function code: {} (dec).\n'.format(subordinateaddress, functioncode)
     except:
-        output += '\nCould not extract slave address and function code. \n\n'
+        output += '\nCould not extract subordinate address and function code. \n\n'
 
     # Check message validity
     try:
-        extractedpayload = _extractPayload(inputstr, slaveaddress, mode, functioncode)
+        extractedpayload = _extractPayload(inputstr, subordinateaddress, mode, functioncode)
         output += 'Valid message. Extracted payload: {!r}\n'.format(extractedpayload)
     except (ValueError, TypeError) as err:
         output += '\nThe message does not seem to be valid Modbus {}. Error message: \n{}. \n\n'.format(mode.upper(), err.message)
     except NameError as err:
-        output += '\nNo message validity checking. \n\n' # Slave address or function code not available
+        output += '\nNo message validity checking. \n\n' # Subordinate address or function code not available
 
     # Generate table describing the message
     if mode == MODE_RTU:
@@ -2427,7 +2427,7 @@ def _interpretRawMessage(inputstr):
         output += '------------------------------------------------- \n'
         for i, character in enumerate(inputstr):
             if i==0:
-                description = 'Slave address'
+                description = 'Subordinate address'
             elif i==1:
                 description = 'Function code'
             elif i==len(inputstr)-2:
@@ -2456,7 +2456,7 @@ def _interpretRawMessage(inputstr):
                 
             else:
                 if i == 1:
-                    description = 'Slave address'
+                    description = 'Subordinate address'
                 elif i == 3:
                     description = 'Function code'
                 elif i == len(inputstr)-4:

--- a/devices/minimalmodbus.py
+++ b/devices/minimalmodbus.py
@@ -74,15 +74,15 @@ CLOSE_PORT_AFTER_EACH_CALL = False
 
 
 class Instrument():
-    """Instrument class for talking to instruments (slaves) via the Modbus RTU protocol (via RS485 or RS232).
+    """Instrument class for talking to instruments (subordinates) via the Modbus RTU protocol (via RS485 or RS232).
 
     Args:
         * port (str): The serial port name, for example ``/dev/ttyUSB0`` (Linux), ``/dev/tty.usbserial`` (OS X) or ``COM4`` (Windows).
-        * slaveaddress (int): Slave address in the range 1 to 247 (use decimal numbers, not hex).
+        * subordinateaddress (int): Subordinate address in the range 1 to 247 (use decimal numbers, not hex).
 
     """
 
-    def __init__(self, port, slaveaddress, stop_bits=STOPBITS):
+    def __init__(self, port, subordinateaddress, stop_bits=STOPBITS):
         if port not in _SERIALPORTS or not _SERIALPORTS[port]:
             self.serial = _SERIALPORTS[port] = serial.Serial(port=port, baudrate=BAUDRATE, parity=PARITY, bytesize=BYTESIZE, stopbits=stop_bits, timeout=TIMEOUT)
         else:
@@ -106,8 +106,8 @@ class Instrument():
                 - Defaults to :data:`TIMEOUT`.
         """
 
-        self.address = slaveaddress
-        """Slave address (int). Most often set by the constructor (see the class documentation). """
+        self.address = subordinateaddress
+        """Subordinate address (int). Most often set by the constructor (see the class documentation). """
 
         self.debug = False
         """Set this to :const:`True` to print the communication details. Defaults to :const:`False`."""
@@ -140,14 +140,14 @@ class Instrument():
 
 
     ########################################
-    ## Functions for talking to the slave ##
+    ## Functions for talking to the subordinate ##
     ########################################
 
     def read_bit(self, registeraddress, functioncode=2):
-        """Read one bit from the slave.
+        """Read one bit from the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 1 or 2.
 
         Returns:
@@ -162,10 +162,10 @@ class Instrument():
 
 
     def write_bit(self, registeraddress, value, functioncode=5):
-        """Write one bit to the slave.
+        """Write one bit to the subordinate.
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * value (int): 0 or 1
             * functioncode (int): Modbus function code. Can be 5 or 15.
 
@@ -182,17 +182,17 @@ class Instrument():
 
 
     def read_register(self, registeraddress, numberOfDecimals=0, functioncode=3, signed=False):
-        """Read an integer from one 16-bit register in the slave, possibly scaling it.
+        """Read an integer from one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register address (use decimal numbers, not hex).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value.
 
         Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value.
@@ -207,7 +207,7 @@ class Instrument():
         negative return values (two's complement).
 
         ============== ================== ================ ===============
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ===============
         :const:`False` Unsigned INT16     Unsigned short   0 to 65535
         :const:`True`  INT16              Short            -32768 to 32767
@@ -227,21 +227,21 @@ class Instrument():
 
 
     def write_register(self, registeraddress, value, numberOfDecimals=0, functioncode=16, signed=False):
-        """Write an integer to one 16-bit register in the slave, possibly scaling it.
+        """Write an integer to one 16-bit register in the subordinate, possibly scaling it.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register address  (use decimal numbers, not hex).
-            * value (int or float): The value to store in the slave register (might be scaled before sending).
+            * registeraddress (int): The subordinate register address  (use decimal numbers, not hex).
+            * value (int or float): The value to store in the subordinate register (might be scaled before sending).
             * numberOfDecimals (int): The number of decimals for content conversion.
             * functioncode (int): Modbus function code. Can be 6 or 16.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
-        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the slave register will hold it as 770 internally.
-        This will multiply ``value`` by 10 before sending it to the slave register.
+        To store for example ``value=77.0``, use ``numberOfDecimals=1`` if the subordinate register will hold it as 770 internally.
+        This will multiply ``value`` by 10 before sending it to the subordinate register.
 
-        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+        Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
         For discussion on negative values, the range and on alternative names, see :meth:`.read_register`.
 
@@ -265,17 +265,17 @@ class Instrument():
 
 
     def read_long(self, registeraddress, functioncode=3, signed=False):
-        """Read a long integer (32 bits) from the slave.
+        """Read a long integer (32 bits) from the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         ============== ================== ================ ==========================
-        ``signed``     Data type in slave Alternative name Range
+        ``signed``     Data type in subordinate Alternative name Range
         ============== ================== ================ ==========================
         :const:`False` Unsigned INT32     Unsigned long    0 to 4294967295
         :const:`True`  INT32              Long             -2147483648 to 2147483647
@@ -294,9 +294,9 @@ class Instrument():
 
 
     def write_long(self, registeraddress, value, signed=False):
-        """Write a long integer (32 bits) to the slave.
+        """Write a long integer (32 bits) to the subordinate.
 
-        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+        Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
@@ -304,8 +304,8 @@ class Instrument():
         and on alternative names, see :meth:`.read_long`.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * value (int or long): The value to store in the slave.
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * value (int or long): The value to store in the subordinate.
             * signed (bool): Whether the data should be interpreted as unsigned or signed.
 
         Returns:
@@ -324,9 +324,9 @@ class Instrument():
 
 
     def read_float(self, registeraddress, functioncode=3, numberOfRegisters=2):
-        """Read a floating point number from the slave.
+        """Read a floating point number from the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave. The
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
         There are differences in the byte order used by different manufacturers. A floating
@@ -337,12 +337,12 @@ class Instrument():
         required by anyone (see support section).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * functioncode (int): Modbus function code. Can be 3 or 4.
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         ====================================== ================= =========== =================
-        Type of floating point number in slave Size              Registers   Range
+        Type of floating point number in subordinate Size              Registers   Range
         ====================================== ================= =========== =================
         Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
         Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -361,17 +361,17 @@ class Instrument():
 
 
     def write_float(self, registeraddress, value, numberOfRegisters=2):
-        """Write a floating point number to the slave.
+        """Write a floating point number to the subordinate.
 
-        Floats are stored in two or more consecutive 16-bit registers in the slave.
+        Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
         Uses Modbus function code 16.
 
         For discussion on precision, number of registers and on byte order, see :meth:`.read_float`.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * value (float or int): The value to store in the slave
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * value (float or int): The value to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the float. Can be 2 or 4.
 
         Returns:
@@ -388,13 +388,13 @@ class Instrument():
 
 
     def read_string(self, registeraddress, numberOfRegisters=16, functioncode=3):
-        """Read a string from the slave.
+        """Read a string from the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers allocated for the string.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -412,16 +412,16 @@ class Instrument():
 
 
     def write_string(self, registeraddress, textstring, numberOfRegisters=16):
-        """Write a string to the slave.
+        """Write a string to the subordinate.
 
-        Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+        Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
         For example 16 consecutive registers can hold 32 characters (32 bytes).
 
         Uses Modbus function code 16.
 
         Args:
-            * registeraddress (int): The slave register start address  (use decimal numbers, not hex).
-            * textstring (str): The string to store in the slave
+            * registeraddress (int): The subordinate register start address  (use decimal numbers, not hex).
+            * textstring (str): The string to store in the subordinate
             * numberOfRegisters (int): The number of registers allocated for the string.
 
         If the textstring is longer than the 2*numberOfRegisters, an error is raised.
@@ -441,12 +441,12 @@ class Instrument():
 
 
     def read_registers(self, registeraddress, numberOfRegisters, functioncode=3):
-        """Read integers from 16-bit registers in the slave.
+        """Read integers from 16-bit registers in the subordinate.
 
-        The slave registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate registers can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
             * numberOfRegisters (int): The number of registers to read.
             * functioncode (int): Modbus function code. Can be 3 or 4.
 
@@ -467,17 +467,17 @@ class Instrument():
 
 
     def write_registers(self, registeraddress, values):
-        """Write integers to 16-bit registers in the slave.
+        """Write integers to 16-bit registers in the subordinate.
 
-        The slave register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
+        The subordinate register can hold integer values in the range 0 to 65535 ("Unsigned INT16").
 
         Uses Modbus function code 16.
 
         The number of registers that will be written is defined by the length of the ``values`` list.
 
         Args:
-            * registeraddress (int): The slave register start address (use decimal numbers, not hex).
-            * values (list of int): The values to store in the slave registers.
+            * registeraddress (int): The subordinate register start address (use decimal numbers, not hex).
+            * values (list of int): The values to store in the subordinate registers.
 
         Any scaling of the register data, or converting it to negative number (two's complement)
         must be done manually.
@@ -514,9 +514,9 @@ class Instrument():
             * signed (bool): Whether the data should be interpreted as unsigned or signed. Only for a single register or for payloadformat='long'.
             * payloadformat (None or string): None, 'long', 'float', 'string', 'register', 'registers'. Not necessary for single registers or bits.
 
-        If a value of 77.0 is stored internally in the slave register as 770, then use ``numberOfDecimals=1``
+        If a value of 77.0 is stored internally in the subordinate register as 770, then use ``numberOfDecimals=1``
         which will divide the received data by 10 before returning the value. Similarly ``numberOfDecimals=2`` will divide the received data by 100 before returning the value. Same functionality also
-        when writing data to the slave.
+        when writing data to the subordinate.
 
         Returns:
             The register data in numerical value (int or float), or the bit value 0 or 1 (int), or ``None``.
@@ -614,25 +614,25 @@ class Instrument():
                 raise ValueError('The list length does not match number of registers. ' + \
                     'List: {0!r},  Number of registers: {1!r}.'.format(value, numberOfRegisters))
 
-        ## Build payload to slave ##
+        ## Build payload to subordinate ##
         if functioncode in [1, 2]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS)
 
         elif functioncode in [3, 4]:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters)
 
         elif functioncode == 5:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _createBitpattern(functioncode, value)
 
         elif functioncode == 6:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(value, numberOfDecimals, signed=signed)
 
         elif functioncode == 15:
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(NUMBER_OF_BITS) + \
                             _numToOneByteString(NUMBER_OF_BYTES_FOR_ONE_BIT) + \
                             _createBitpattern(functioncode, value)
@@ -654,37 +654,37 @@ class Instrument():
                 registerdata = _valuelistToBytestring(value, numberOfRegisters)
 
             assert len(registerdata) == numberOfRegisterBytes
-            payloadToSlave =_numToTwoByteString(registeraddress) + \
+            payloadToSubordinate =_numToTwoByteString(registeraddress) + \
                             _numToTwoByteString(numberOfRegisters) + \
                             _numToOneByteString(numberOfRegisterBytes) + \
                             registerdata
 
         ## Communicate ##
-        payloadFromSlave = self._performCommand(functioncode, payloadToSlave)
+        payloadFromSubordinate = self._performCommand(functioncode, payloadToSubordinate)
 
         ## Check the contents in the response payload ##
         if functioncode in [1, 2, 3, 4]:
-            _checkResponseByteCount(payloadFromSlave)  # response byte count
+            _checkResponseByteCount(payloadFromSubordinate)  # response byte count
 
         if functioncode in [5, 6, 15, 16]:
-            _checkResponseRegisterAddress(payloadFromSlave, registeraddress)  # response register address
+            _checkResponseRegisterAddress(payloadFromSubordinate, registeraddress)  # response register address
 
         if functioncode == 5:
-            _checkResponseWriteData(payloadFromSlave, _createBitpattern(functioncode, value))  # response write data
+            _checkResponseWriteData(payloadFromSubordinate, _createBitpattern(functioncode, value))  # response write data
 
         if functioncode == 6:
-            _checkResponseWriteData(payloadFromSlave, \
+            _checkResponseWriteData(payloadFromSubordinate, \
                 _numToTwoByteString(value, numberOfDecimals, signed=signed))  # response write data
 
         if functioncode == 15:
-            _checkResponseNumberOfRegisters(payloadFromSlave, NUMBER_OF_BITS)  # response number of bits
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, NUMBER_OF_BITS)  # response number of bits
 
         if functioncode == 16:
-            _checkResponseNumberOfRegisters(payloadFromSlave, numberOfRegisters)  # response number of registers
+            _checkResponseNumberOfRegisters(payloadFromSubordinate, numberOfRegisters)  # response number of registers
 
         ## Calculate return value ##
         if functioncode in [1, 2]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != NUMBER_OF_BYTES_FOR_ONE_BIT:
                 raise ValueError('The registerdata length does not match NUMBER_OF_BYTES_FOR_ONE_BIT. ' + \
                     'Given {0}.'.format(len(registerdata)))
@@ -692,7 +692,7 @@ class Instrument():
             return _bitResponseToValue(registerdata)
 
         if functioncode in [3, 4]:
-            registerdata = payloadFromSlave[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
+            registerdata = payloadFromSubordinate[NUMBER_OF_BYTES_BEFORE_REGISTERDATA:]
             if len(registerdata) != numberOfRegisterBytes:
                 raise ValueError('The registerdata length does not match number of register bytes. ' + \
                     'Given {0!r} and {1!r}.'.format(len(registerdata), numberOfRegisterBytes))
@@ -720,15 +720,15 @@ class Instrument():
     ## Communication implementation details ##
     ##########################################
 
-    def _performCommand(self, functioncode, payloadToSlave):
+    def _performCommand(self, functioncode, payloadToSubordinate):
         """Performs the command having the *functioncode*.
 
         Args:
             * functioncode (int): The function code for the command to be performed. Can for example be 'Write register' = 16.
-            * payloadToSlave (str): Data to be transmitted to the slave (will be embedded in slaveaddress, CRC etc)
+            * payloadToSubordinate (str): Data to be transmitted to the subordinate (will be embedded in subordinateaddress, CRC etc)
 
         Returns:
-            The extracted data payload from the slave (a string). It has been stripped of CRC etc.
+            The extracted data payload from the subordinate (a string). It has been stripped of CRC etc.
 
         Raises:
             ValueError, TypeError.
@@ -739,9 +739,9 @@ class Instrument():
         DEFAULT_NUMBER_OF_BYTES_TO_READ = 1000
         
         _checkFunctioncode(functioncode, None )
-        _checkString(payloadToSlave, description='payload')
+        _checkString(payloadToSubordinate, description='payload')
 
-        message = _embedPayload(self.address, functioncode, payloadToSlave)
+        message = _embedPayload(self.address, functioncode, payloadToSubordinate)
         
         # Calculate number of bytes to read
         if not self.precalculate_read_size:
@@ -759,19 +759,19 @@ class Instrument():
 
         response = self._communicate(message, number_of_bytes_to_read)
         
-        payloadFromSlave = _extractPayload(response, self.address, functioncode)
-        return payloadFromSlave
+        payloadFromSubordinate = _extractPayload(response, self.address, functioncode)
+        return payloadFromSubordinate
 
 
     def _communicate(self, message, number_of_bytes_to_read):
-        """Talk to the slave via a serial port.
+        """Talk to the subordinate via a serial port.
 
         Args:
-            message (str): The raw message that is to be sent to the slave.
+            message (str): The raw message that is to be sent to the subordinate.
             number_of_bytes_to_read (int): number of bytes to read
 
         Returns:
-            The raw data (string) returned from the slave.
+            The raw data (string) returned from the subordinate.
 
         Raises:
             TypeError, ValueError, IOError
@@ -789,9 +789,9 @@ class Instrument():
         
         Timing::
 
-                                                  Request from master (Master is writing)
+                                                  Request from main (Main is writing)
                                                   |
-                                                  |       Response from slave (Master is reading)
+                                                  |       Response from subordinate (Main is reading)
                                                   |       |
             ----W----R----------------------------W-------R----------------------------------------
                      |                            |       |
@@ -817,10 +817,10 @@ class Instrument():
             Note that these strings can look pretty strange when printed, as values 0 to 31 (dec) are
             ASCII control signs. For example 'vertical tab' and 'line feed' are among those.
 
-            The **raw message** to the slave has the frame format: slaveaddress byte + functioncode byte +
+            The **raw message** to the subordinate has the frame format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes).
 
-            The **received message** should have the format: slaveaddress byte + functioncode byte +
+            The **received message** should have the format: subordinateaddress byte + functioncode byte +
             data payload + CRC code (two bytes)
 
             For Python3, the information sent to and from pySerial should be of the type bytes.
@@ -901,41 +901,41 @@ class Instrument():
 # Payload handling #
 ####################
 
-def _embedPayload(slaveaddress, functioncode, payloaddata):
-    """Build a message from the slaveaddress, the function code and the payload data.
+def _embedPayload(subordinateaddress, functioncode, payloaddata):
+    """Build a message from the subordinateaddress, the function code and the payload data.
 
     Args:
-        * slaveaddress (int): The address of the slave.
+        * subordinateaddress (int): The address of the subordinate.
         * functioncode (int): The function code for the command to be performed. Can for example be 16 (Write register).
-        * payloaddata (str): The byte string to be sent to the slave.
+        * payloaddata (str): The byte string to be sent to the subordinate.
 
     Returns:
-        The built (raw) message string for sending to the slave (including CRC etc).
+        The built (raw) message string for sending to the subordinate (including CRC etc).
 
     Raises:
         ValueError, TypeError.
 
-    The resulting message has the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
+    The resulting message has the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes).
 
-    The CRC is calculated from the string made up of slaveaddress byte + functioncode byte + payloaddata.
+    The CRC is calculated from the string made up of subordinateaddress byte + functioncode byte + payloaddata.
 
     """
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
     _checkString(payloaddata, description='payload')
 
     # Build message
-    firstPart = _numToOneByteString(slaveaddress) + _numToOneByteString(functioncode) + payloaddata
+    firstPart = _numToOneByteString(subordinateaddress) + _numToOneByteString(functioncode) + payloaddata
     message = firstPart + _calculateCrcString(firstPart)
     return message
 
 
-def _extractPayload(response, slaveaddress, functioncode):
-    """Extract the payload data part from the slave's response.
+def _extractPayload(response, subordinateaddress, functioncode):
+    """Extract the payload data part from the subordinate's response.
 
     Args:
-        * response (str): The raw response byte string from the slave.
-        * slaveaddress (int): The adress of the slave. Used here for error checking only.
+        * response (str): The raw response byte string from the subordinate.
+        * subordinateaddress (int): The adress of the subordinate. Used here for error checking only.
         * functioncode (int): Used here for error checking only.
 
     Returns:
@@ -944,7 +944,7 @@ def _extractPayload(response, slaveaddress, functioncode):
     Raises:
         ValueError, TypeError. Raises an exception if there is any problem with the received address, the functioncode or the CRC.
 
-    The received message should have the format: slaveaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
+    The received message should have the format: subordinateaddress byte + functioncode byte + payloaddata + CRC (which is two bytes)
 
     """
     BYTEPOSITION_FOR_SLAVEADDRESS          = 0  # Zero-based counting
@@ -955,7 +955,7 @@ def _extractPayload(response, slaveaddress, functioncode):
 
     # Argument validity testing
     _checkString(response, description='response')
-    _checkSlaveaddress(slaveaddress)
+    _checkSubordinateaddress(subordinateaddress)
     _checkFunctioncode(functioncode, None)
         
     # Check CRC
@@ -969,18 +969,18 @@ def _extractPayload(response, slaveaddress, functioncode):
             _twoByteStringToNum(calculatedCRC), calculatedCRC,
             response))
 
-    # Check slave address
+    # Check subordinate address
     responseaddress = ord( response[BYTEPOSITION_FOR_SLAVEADDRESS] )
 
-    if responseaddress != slaveaddress:
-        raise ValueError( 'Wrong return slave address: {0} instead of {1}. The response is: {2!r}'.format( \
-            responseaddress, slaveaddress, response))
+    if responseaddress != subordinateaddress:
+        raise ValueError( 'Wrong return subordinate address: {0} instead of {1}. The response is: {2!r}'.format( \
+            responseaddress, subordinateaddress, response))
 
     # Check function code
     receivedFunctioncode = ord( response[BYTEPOSITION_FOR_FUNCTIONCODE ] )
 
     if receivedFunctioncode == _setBitOn(functioncode, BITNUMBER_FUNCTIONCODE_ERRORINDICATION):
-        raise ValueError('The slave is indicating an error. The response is: {0!r}'.format(response))
+        raise ValueError('The subordinate is indicating an error. The response is: {0!r}'.format(response))
 
     elif receivedFunctioncode != functioncode:
         raise ValueError('Wrong functioncode: {0} instead of {1}. The response is: {2!r}'.format( \
@@ -999,10 +999,10 @@ def _extractPayload(response, slaveaddress, functioncode):
 ############################################
     
 def _predictRtuResponseSize(message):
-    """Calculate the number of bytes that should be received from the slave for Modbus RTU.
+    """Calculate the number of bytes that should be received from the subordinate for Modbus RTU.
     
     Args:
-        message (str): The raw message that is to be sent to the slave.
+        message (str): The raw message that is to be sent to the subordinate.
 
     Returns:
         The preducted number of bytes (int) in the response.
@@ -1104,8 +1104,8 @@ def _numToTwoByteString(value, numberOfDecimals=0, LsbFirst=False, signed=False)
         TypeError, ValueError. Gives DeprecationWarning instead of ValueError
         for some values in Python 2.6.
 
-    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the slave register.
-    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the slave register.
+    Use ``numberOfDecimals=1`` to multiply ``value`` by 10 before sending it to the subordinate register.
+    Similarly ``numberOfDecimals=2`` will multiply ``value`` by 100 before sending it to the subordinate register.
 
     Use the parameter ``signed=True`` if making a bytestring that can hold
     negative values. Then negative input will be automatically converted into
@@ -1198,7 +1198,7 @@ def _twoByteStringToNum(bytestring, numberOfDecimals=0, signed=False):
 def _longToBytestring(value, signed=False, numberOfRegisters=2):
     """Convert a long integer to a bytestring.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * value (int): The numerical value to be converted.
@@ -1230,7 +1230,7 @@ def _longToBytestring(value, signed=False, numberOfRegisters=2):
 def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
     """Convert a bytestring to a long integer.
 
-    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave.
+    Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate.
 
     Args:
         * bytestring (str): A string of length 4.
@@ -1260,11 +1260,11 @@ def _bytestringToLong(bytestring, signed=False, numberOfRegisters=2):
 def _floatToBytestring(value, numberOfRegisters=2):
     """Convert a numerical value to a bytestring.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave. The
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate. The
         encoding is according to the standard IEEE 754.
 
     ====================================== ================= =========== =================
-    Type of floating point number in slave Size              Registers   Range
+    Type of floating point number in subordinate Size              Registers   Range
     ====================================== ================= =========== =================
     Single precision (binary32)            32 bits (4 bytes) 2 registers 1.4E-45 to 3.4E38
     Double precision (binary64)            64 bits (8 bytes) 4 registers 5E-324 to 1.8E308
@@ -1305,7 +1305,7 @@ def _floatToBytestring(value, numberOfRegisters=2):
 def _bytestringToFloat(bytestring, numberOfRegisters=2):
     """Convert a four-byte string to a float.
 
-    Floats are stored in two or more consecutive 16-bit registers in the slave.
+    Floats are stored in two or more consecutive 16-bit registers in the subordinate.
 
     For discussion on precision, number of bits, number of registers, the range, byte order
     and on alternative names, see :func:`minimalmodbus._floatToBytestring`.
@@ -1344,14 +1344,14 @@ def _bytestringToFloat(bytestring, numberOfRegisters=2):
 def _textstringToBytestring(inputstring, numberOfRegisters=16):
     """Convert a text string to a bytestring.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking and string padding.
     If the inputstring is shorter that the allocated space, it is padded with spaces in the end.
 
     Args:
-        * inputstring (str): The string to be stored in the slave. Max 2*numberOfRegisters characters.
+        * inputstring (str): The string to be stored in the subordinate. Max 2*numberOfRegisters characters.
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1373,13 +1373,13 @@ def _textstringToBytestring(inputstring, numberOfRegisters=16):
 def _bytestringToTextstring(bytestring, numberOfRegisters=16):
     """Convert a bytestring to a text string.
 
-    Each 16-bit register in the slave are interpreted as two characters (1 byte = 8 bits).
+    Each 16-bit register in the subordinate are interpreted as two characters (1 byte = 8 bits).
     For example 16 consecutive registers can hold 32 characters (32 bytes).
 
     Not much of conversion is done, mostly error checking.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers allocated for the string.
 
     Returns:
@@ -1443,7 +1443,7 @@ def _bytestringToValuelist(bytestring, numberOfRegisters):
     The bytestring is interpreted as 'unsigned INT16'.
 
     Args:
-        * bytestring (str): The string from the slave. Length = 2*numberOfRegisters
+        * bytestring (str): The string from the subordinate. Length = 2*numberOfRegisters
         * numberOfRegisters (int): The number of registers. For error checking.
 
     Returns:
@@ -1808,11 +1808,11 @@ def _checkFunctioncode(functioncode, listOfAllowedValues=[]):
         raise ValueError('Wrong function code: {0}, allowed values are {1!r}'.format(functioncode, listOfAllowedValues))
 
 
-def _checkSlaveaddress(slaveaddress):
-    """Check that the given slaveaddress is valid.
+def _checkSubordinateaddress(subordinateaddress):
+    """Check that the given subordinateaddress is valid.
 
     Args:
-        slaveaddress (int): The slave address
+        subordinateaddress (int): The subordinate address
 
     Raises:
         TypeError, ValueError
@@ -1821,7 +1821,7 @@ def _checkSlaveaddress(slaveaddress):
     SLAVEADDRESS_MAX = 247
     SLAVEADDRESS_MIN = 0
 
-    _checkInt(slaveaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='slaveaddress')
+    _checkInt(subordinateaddress, SLAVEADDRESS_MIN, SLAVEADDRESS_MAX, description='subordinateaddress')
 
 
 def _checkRegisteraddress(registeraddress):

--- a/devices/test_eurotherm3500.py
+++ b/devices/test_eurotherm3500.py
@@ -180,8 +180,8 @@ RESPONSES['\x01\x03' + '\x01\x0c\x00\x01' + 'E\xf5']    = '\x01\x03' + '\x02\x00
 
 # get_pv_loop1: Return value 77.0
 # -----------------------------------------------------------------#
-# Message:  slave address 1, function code 3, register address 289, 1 register, CRC. 
-# Response: slave address 1, function code 3, 2 bytes, value=770, CRC=14709
+# Message:  subordinate address 1, function code 3, register address 289, 1 register, CRC. 
+# Response: subordinate address 1, function code 3, 2 bytes, value=770, CRC=14709
 RESPONSES['\x01\x03' + '\x01!\x00\x01' + '\xd5\xfc']    = '\x01\x03' + '\x02\x03\x02' + '\x39\x75'
 
 # get_pv_loop2(): Return value 19.2 

--- a/devices/voegtlin_gsc.py
+++ b/devices/voegtlin_gsc.py
@@ -44,13 +44,13 @@ class voegtlin_gsc( minimalmodbus.Instrument ):
     read_string(self, registeraddress, numberOfRegisters=16, functioncode=3)
     write_string(self, registeraddress, textstring, numberOfRegisters=16)
     
-    !! Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the slave
+    !! Long integers (32 bits = 4 bytes) are stored in two consecutive 16-bit registers in the subordinate
     read_long(self, registeraddress, functioncode=3, signed=False)
     write_long(self, registeraddress, value, signed=False)
     
     Args:
         * portname (str): port name
-        * slaveaddress (int): slave address in the range 1 to 247
+        * subordinateaddress (int): subordinate address in the range 1 to 247
 
     Implemented with these function codes (in decimal):
         
@@ -64,14 +64,14 @@ class voegtlin_gsc( minimalmodbus.Instrument ):
 
     """
     
-    def __init__(self, portname, slaveaddresses, voegtlin_debug=False, stop_bits=2):
-        if type(slaveaddresses)==float or type(slaveaddresses)==int:
-            slaveaddresses = [int(slaveaddresses)] # make an array
-        minimalmodbus.Instrument.__init__(self, portname, slaveaddresses[0], stop_bits=2) # connect to the first one
+    def __init__(self, portname, subordinateaddresses, voegtlin_debug=False, stop_bits=2):
+        if type(subordinateaddresses)==float or type(subordinateaddresses)==int:
+            subordinateaddresses = [int(subordinateaddresses)] # make an array
+        minimalmodbus.Instrument.__init__(self, portname, subordinateaddresses[0], stop_bits=2) # connect to the first one
         # sort out all addresses where no device is present
         self.mfc_addresses = []
         self.voegtlin_debug = voegtlin_debug
-        for test_address in slaveaddresses:
+        for test_address in subordinateaddresses:
             if self.set_flowmeter_address(test_address):
                 self.mfc_addresses.append(test_address)
         return

--- a/devices/wpi_aladdin_1000.py
+++ b/devices/wpi_aladdin_1000.py
@@ -29,7 +29,7 @@ class wpi_aladdin_1000():
 
     Args:
         * portname (str): port name
-        * slaveaddress (int): slave address. default 0
+        * subordinateaddress (int): subordinate address. default 0
 
 
 
@@ -55,9 +55,9 @@ class wpi_aladdin_1000():
     
        
     """    
-    def __init__(self, portname, slaveaddress=0):
+    def __init__(self, portname, subordinateaddress=0):
         self.debug = True
-        self.slaveaddress = slaveaddress
+        self.subordinateaddress = subordinateaddress
         self.pump_name = str(portname)
         self.CR = '\x0D'
         self.STX = '\x02'
@@ -78,9 +78,9 @@ class wpi_aladdin_1000():
     
     ## Process value
     def write(self,message):
-        self.interface.write(str(self.slaveaddress)+" "+message+self.CR)
+        self.interface.write(str(self.subordinateaddress)+" "+message+self.CR)
         if self.debug:
-            print "Just wrote:",str(self.slaveaddress)+" "+message
+            print "Just wrote:",str(self.subordinateaddress)+" "+message
         return
      
     def read(self):


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.